### PR TITLE
Cancel animations in onViewDetachedFromWindow since they prevent ViewHolders from being recycled

### DIFF
--- a/sample/src/main/java/com/rubensousa/dpadrecyclerview/sample/ui/screen/compose/NestedComposeListAdapter.kt
+++ b/sample/src/main/java/com/rubensousa/dpadrecyclerview/sample/ui/screen/compose/NestedComposeListAdapter.kt
@@ -59,6 +59,10 @@ class NestedComposeListAdapter(
         holder.item?.let {
             scrollState.save(holder.getRecyclerView(), it.diffId)
         }
+    }
+
+    override fun onViewDetachedFromWindow(holder: NestedComposeListViewHolder) {
+        super.onViewDetachedFromWindow(holder)
         holder.cancelAnimations()
     }
 

--- a/sample/src/main/java/com/rubensousa/dpadrecyclerview/sample/ui/screen/list/HorizontalListAdapter.kt
+++ b/sample/src/main/java/com/rubensousa/dpadrecyclerview/sample/ui/screen/list/HorizontalListAdapter.kt
@@ -80,4 +80,8 @@ class HorizontalListAdapter(
         holder.recycle()
     }
 
+    override fun onViewDetachedFromWindow(holder: HorizontalListViewHolder) {
+        holder.cancelAnimations()
+    }
+
 }

--- a/sample/src/main/java/com/rubensousa/dpadrecyclerview/sample/ui/screen/list/HorizontalListViewHolder.kt
+++ b/sample/src/main/java/com/rubensousa/dpadrecyclerview/sample/ui/screen/list/HorizontalListViewHolder.kt
@@ -82,6 +82,10 @@ class HorizontalListViewHolder(
         animator.startDeselectionAnimation()
     }
 
+    fun cancelAnimations() {
+        animator.cancel()
+    }
+
     override fun getSubPositionAlignments(): List<SubPositionAlignment> {
         return alignments
     }


### PR DESCRIPTION
Fixes: https://github.com/rubensousa/DpadRecyclerView/issues/236