### PR TITLE
Do not align to start if anchor is closer to the keyline

### DIFF
--- a/dpadrecyclerview/src/androidTest/kotlin/com/rubensousa/dpadrecyclerview/test/helpers/RecyclerViewTestExtensions.kt
+++ b/dpadrecyclerview/src/androidTest/kotlin/com/rubensousa/dpadrecyclerview/test/helpers/RecyclerViewTestExtensions.kt
@@ -242,3 +242,4 @@ fun swipeVerticallyBy(dy: Int) {
         )
 }
 
+

--- a/dpadrecyclerview/src/androidTest/kotlin/com/rubensousa/dpadrecyclerview/test/tests/alignment/VerticalAlignmentTest.kt
+++ b/dpadrecyclerview/src/androidTest/kotlin/com/rubensousa/dpadrecyclerview/test/tests/alignment/VerticalAlignmentTest.kt
@@ -370,6 +370,33 @@ class VerticalAlignmentTest : DpadRecyclerViewTest() {
     }
 
     @Test
+    fun testShortListAlignmentWithMinEdgeStillAlignsToKeyline() {
+        // given
+        val parentAlignment = ParentAlignment(
+            edge = Edge.MIN,
+            offset = 0,
+            fraction = 0.5f,
+            isFractionEnabled = true,
+            preferKeylineOverEdge = false
+        )
+
+        launchFragment(
+            getDefaultLayoutConfiguration().copy(parentAlignment = parentAlignment),
+            getDefaultAdapterConfiguration().copy(numberOfItems = 6)
+        )
+
+        // when
+        repeat(4) {
+            KeyEvents.pressDown(times = 1)
+            waitForIdleScrollState()
+        }
+
+        // then
+        assertThat(getItemViewBounds(position = 4).centerY())
+            .isEqualTo(getRecyclerViewBounds().centerY())
+    }
+
+    @Test
     fun testLayoutAlignsToKeylineWhenThereAreNotManyItemsAndEdgeMaxIsUsed() {
         val parentAlignment = ParentAlignment(
             edge = Edge.MAX,

--- a/dpadrecyclerview/src/main/java/com/rubensousa/dpadrecyclerview/layoutmanager/alignment/ParentAlignmentCalculator.kt
+++ b/dpadrecyclerview/src/main/java/com/rubensousa/dpadrecyclerview/layoutmanager/alignment/ParentAlignmentCalculator.kt
@@ -225,7 +225,9 @@ internal class ParentAlignmentCalculator {
         if (isLayoutComplete()) {
             return viewAnchor + getLayoutAbsoluteStart() <= startEdge + keyline
         }
-        return isLayoutStartKnown() && !preferKeylineOverEdge(alignment)
+        return isLayoutStartKnown()
+                && !preferKeylineOverEdge(alignment)
+                && viewAnchor < keyline
     }
 
     private fun shouldAlignViewToEnd(
@@ -239,7 +241,9 @@ internal class ParentAlignmentCalculator {
         if (isLayoutComplete()) {
             return viewAnchor + getLayoutAbsoluteEnd() >= endEdge + keyline
         }
-        return isLayoutStartKnown() && !preferKeylineOverEdge(alignment)
+        return isLayoutStartKnown()
+                && !preferKeylineOverEdge(alignment)
+                && viewAnchor > keyline
     }
 
     private fun calculateScrollOffsetToKeyline(anchor: Int, keyline: Int): Int {

--- a/sample/src/main/java/com/rubensousa/dpadrecyclerview/sample/ui/screen/list/ShortListFragment.kt
+++ b/sample/src/main/java/com/rubensousa/dpadrecyclerview/sample/ui/screen/list/ShortListFragment.kt
@@ -26,14 +26,16 @@ class ShortListFragment : Fragment(R.layout.screen_recyclerview) {
         binding.recyclerView.apply {
             setParentAlignment(
                 ParentAlignment(
-                    edge = ParentAlignment.Edge.NONE,
-                    fraction = 0.5f
+                    edge = ParentAlignment.Edge.MIN,
+                    offset = 0,
+                    fraction = 0.5f,
+                    isFractionEnabled = true,
+                    preferKeylineOverEdge = false
                 )
             )
-            setFocusableDirection(FocusableDirection.CIRCULAR)
             setItemSpacing(dpToPx(16.dp))
             adapter = Adapter(
-                items = List(4) { i ->
+                items = List(8) { i ->
                     "Item $i"
                 }
             )


### PR DESCRIPTION
Fixes: #291 